### PR TITLE
Set default run options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,12 @@ RUN \
 
 FROM alpine:3.9
 
+EXPOSE 22124/udp
+
 RUN apk add --update --no-cache \
     qt-x11 icu-libs
 
 COPY --from=builder /usr/local/bin/Jamulus /usr/local/bin/Jamulus
-ENTRYPOINT ["Jamulus"]
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod 755 /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,19 @@ The Jamulus software enables musicians to perform real-time jam sessions over th
 
 Here are some example snippets to help you get started creating a container.
 
-## docker
+## docker: minimum setup
+
+This starts with the default options: "-s -n"
+
+```bash
+docker run \
+  --name jamulus \
+  -d --rm \
+  -p 22124:22124/udp \
+  grundic/jamulus
+```
+
+## docker: custom options
 
 ```bash
 docker run \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ $# -eq 0 ]; then
+   echo "launching default server"
+   exec Jamulus -s -n
+fi
+exec Jamulus "$@"


### PR DESCRIPTION
This sets the default run options. That is run:

`Jamulus -s -n`

if no options are defined. 

This should reduce the complexity ;-)