### PR TITLE
Use Github tar.gz release export directly instead of Sourceforge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.9 as builder
 
-ENV JAMULUS_VERSION 3.4.4
+ENV JAMULUS_VERSION 3_4_7
 
 RUN \
  echo "**** updating system packages ****" && \
@@ -16,11 +16,11 @@ RUN \
 WORKDIR /tmp
 RUN \
  echo "**** getting source code ****" && \
-   wget "https://netix.dl.sourceforge.net/project/llcon/Jamulus/${JAMULUS_VERSION}/Jamulus-${JAMULUS_VERSION}.tar.gz" && \
-   tar xzf Jamulus-${JAMULUS_VERSION}.tar.gz
+   wget "https://github.com/softins/jamulus/archive/r${JAMULUS_VERSION}.tar.gz" && \
+   tar xzf r${JAMULUS_VERSION}.tar.gz
 
-# no dash between name and version.
-WORKDIR /tmp/Jamulus${JAMULUS_VERSION}
+# Github directory format for tar.gz export
+WORKDIR /tmp/jamulus-r${JAMULUS_VERSION}
 RUN \
  echo "**** compiling source code ****" && \
    qmake "CONFIG+=nosound" Jamulus.pro && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN \
 WORKDIR /tmp
 RUN \
  echo "**** getting source code ****" && \
-   wget "https://github.com/softins/jamulus/archive/r${JAMULUS_VERSION}.tar.gz" && \
+   wget "https://github.com/corrados/jamulus/archive/r${JAMULUS_VERSION}.tar.gz" && \
    tar xzf r${JAMULUS_VERSION}.tar.gz
 
 # Github directory format for tar.gz export


### PR DESCRIPTION
For the last three releases (3.4.5-3.4.7), no tar.gz has been exported to Sourceforge.

This change uses instead the automatic tar.gz creation provided by Github for a tagged release.

Note that the version number needs to use underscores in this case.