### PR TITLE
Added CONFIG+=headless flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN \
 WORKDIR /tmp/jamulus-r${JAMULUS_VERSION}
 RUN \
  echo "**** compiling source code ****" && \
-   qmake "CONFIG+=nosound" Jamulus.pro && \
+   qmake "CONFIG+=nosound headless" Jamulus.pro && \
    make clean && \
    make && \
    cp Jamulus /usr/local/bin/ && \


### PR DESCRIPTION
Since the use case is a headless server, the headless CONFIG parameter should be added. This improves the compilation speed and the resulting Jamulus binary is smaller.